### PR TITLE
Add automatic updates to module

### DIFF
--- a/module.prop
+++ b/module.prop
@@ -4,3 +4,4 @@ version=v6
 versionCode=6
 author=TJJ
 description=Framework for installing the Google Dialer/Google Phone on Android
+updateJson=https://raw.githubusercontent.com/Magisk-Modules-Repo/GoogleDialerFramework/master/update_info.json

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=GoogleDialerFramework
 name=Dialer Framework for Google Phone
-version=v6
-versionCode=6
+version=v7
+versionCode=7
 author=TJJ
 description=Framework for installing the Google Dialer/Google Phone on Android
 updateJson=https://raw.githubusercontent.com/Magisk-Modules-Repo/GoogleDialerFramework/master/update_info.json

--- a/update_info.json
+++ b/update_info.json
@@ -1,6 +1,6 @@
 {
-    "version": v6,
-    "versionCode": 6,
-    "zipUrl": https://github.com/Magisk-Modules-Repo/GoogleDialerFramework/archive/refs/tags/v6.zip,
-    "changelog": https://github.com/Magisk-Modules-Repo/GoogleDialerFramework/releases/tag/v6,
+    "version": v7,
+    "versionCode": 7,
+    "zipUrl": https://github.com/Magisk-Modules-Repo/GoogleDialerFramework/archive/refs/tags/v7.zip,
+    "changelog": https://github.com/Magisk-Modules-Repo/GoogleDialerFramework/releases/tag/v7,
 }

--- a/update_info.json
+++ b/update_info.json
@@ -1,6 +1,6 @@
 {
-    "version": v7,
+    "version": "v7",
     "versionCode": 7,
-    "zipUrl": https://github.com/Magisk-Modules-Repo/GoogleDialerFramework/archive/refs/tags/v7.zip,
-    "changelog": https://github.com/Magisk-Modules-Repo/GoogleDialerFramework/releases/tag/v7,
+    "zipUrl": "https://github.com/Magisk-Modules-Repo/GoogleDialerFramework/archive/refs/tags/v7.zip",
+    "changelog": "https://github.com/Magisk-Modules-Repo/GoogleDialerFramework/releases/tag/v7",
 }

--- a/update_info.json
+++ b/update_info.json
@@ -1,0 +1,6 @@
+{
+    "version": v6,
+    "versionCode": 6,
+    "zipUrl": https://github.com/Magisk-Modules-Repo/GoogleDialerFramework/archive/refs/tags/v6.zip,
+    "changelog": https://github.com/Magisk-Modules-Repo/GoogleDialerFramework/releases/tag/v6,
+}


### PR DESCRIPTION
This should allow for automatic update in Magisk.
The implementation follows this: https://topjohnwu.github.io/Magisk/guides.html

After merging, v7 needs to be tagged, so that the download links work.